### PR TITLE
Changing config format and adding option for it to be a whitelist 

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,5 @@
 Requires CounterStrikeSharp
 
 Once loaded, the plugin will generate a config file where you can add the weapons you want to be completely restricted from the game.
+
+The generated config has a parameter if you would like the file to be treated as a whitelist (when true, listed weapons are allowed) instead of a blacklist (when false, listed weapons are not allowed).


### PR DESCRIPTION
I understand you wrote you aren't adding features, only fixing bugs. I thought it'd be useful to have the config toggleable between whitelist/blacklist so I just tried adding that functionality myself. Not too comfortable with C# but this seems to work fine, except...

Null reference errors occur when plugin hotloads for the first time. If hotloading previously did work without throwing errors, I'll look into fixing that myself, but if it's a problem that already exists I don't feel like fixing it right now.

New example format of generated config (what I just threw on gloveworks, idk if these are all the knife names):

```
{
  "Whitelist": true,
  "Names": [
    "weapon_deagle",
    "weapon_bayonet",
    "weapon_m9_bayonet",
    "weapon_butterfly",
    "weapon_falchion",
    "weapon_flip",
    "weapon_gut",
    "weapon_tactical",
    "weapon_karambit",
    "weapon_survival_bowie",
    "weapon_knife",
    "weapon_knife_push",
    "weapon_knife_t",
    "weapon_knife_ct",
    "weapon_knifegg",
    "weapon_knife_ursus",
    "weapon_knife_gypsy_jackknife",
    "weapon_knife_stiletto",
    "weapon_knife_widowmaker",
    "weapon_knife_canis",
    "weapon_knife_cord",
    "weapon_knife_skeleton",
    "weapon_knife_outdoor"
  ]
}
```